### PR TITLE
ArgumentParser.add_argument fix.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -27,8 +27,13 @@ from sys import exit as quit
 
 if __name__ == '__main__':
     parser = ArgumentParser(prog="gps.py")
-    parser.add_argument("profile_name", dest="user", nargs="?", type=str,
-        help="Your GitHub profile name")
+    parser.add_argument(
+        metavar="profile_name",
+        dest="user",
+        nargs="?",
+        type=str,
+        help="Your GitHub profile name"
+    )
     args = parser.parse_args()
     user = args.user
     if not user:


### PR DESCRIPTION
Traceback (most recent call last):
  File "main.py", line 31, in <module>
    help="Your GitHub profile name")
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/argparse.py", line 1334, in add_argument
    raise ValueError('dest supplied twice for positional argument')
ValueError: dest supplied twice for positional argument